### PR TITLE
Use RtlGenRandom if BCryptGenRandom fails

### DIFF
--- a/random/random.c
+++ b/random/random.c
@@ -10,12 +10,12 @@
 #include <stdlib.h>
 #include <stdbool.h>
 #if defined(__WINDOWS__)
-    #include <windows.h>
-    #include <bcrypt.h>
+	#include <windows.h>
+	#include <bcrypt.h>
 #elif defined(__LINUX__)
-    #include <unistd.h>
-    #include <fcntl.h>
-    static int lock = -1;
+	#include <unistd.h>
+	#include <fcntl.h>
+	static int lock = -1;
 #endif
 
 #if defined(__WINDOWS__)
@@ -37,44 +37,52 @@ int random_bytes(unsigned char* random_array, unsigned int nbytes)
 { // Generation of "nbytes" of random values
 
 #if defined(__WINDOWS__)	
-    if (BCRYPT_SUCCESS(last_bcrypt_error))
-    {
-        NTSTATUS status = BCryptGenRandom(
-            NULL, random_array, nbytes, BCRYPT_USE_SYSTEM_PREFERRED_RNG);
+	if (BCRYPT_SUCCESS(last_bcrypt_error))
+	{
+		NTSTATUS status = BCryptGenRandom(
+			NULL, random_array, nbytes, BCRYPT_USE_SYSTEM_PREFERRED_RNG);
 
-        if (BCRYPT_SUCCESS(status))
-        {
-            return true;
-        }
+		if (BCRYPT_SUCCESS(status))
+		{
+			return true;
+		}
 
-        last_bcrypt_error = status;
-    }
+		last_bcrypt_error = status;
+	}
 
-    HMODULE hAdvApi = LoadLibraryA("ADVAPI32.DLL");
-    if (hAdvApi)
-    {
-        BOOLEAN(APIENTRY * RtlGenRandom)
-            (void*, ULONG) = (BOOLEAN(APIENTRY*)(void*, ULONG))GetProcAddress(hAdvApi, RTL_GENRANDOM);
+	HMODULE hAdvApi = LoadLibraryA("ADVAPI32.DLL");
+	if (!hAdvApi)
+	{
+		return false;
+	}
 
-        if (!RtlGenRandom || !RtlGenRandom(random_array, nbytes))
-        {
-            return false;
-        }
+	BOOLEAN(APIENTRY * RtlGenRandom)
+		(void*, ULONG) = (BOOLEAN(APIENTRY*)(void*, ULONG))GetProcAddress(hAdvApi, RTL_GENRANDOM);
 
-        FreeLibrary(hAdvApi);
-    }
+	BOOLEAN genrand_result = FALSE;
+	if (RtlGenRandom)
+	{
+		genrand_result = RtlGenRandom(random_array, nbytes);
+	}
+
+	FreeLibrary(hAdvApi);
+
+	if (!genrand_result)
+	{
+		return false;
+	}
 
 #elif defined(__LINUX__)
 	int r, n = nbytes, count = 0;
-    
-    if (lock == -1) {
-	    do {
-		    lock = open("/dev/urandom", O_RDONLY);
-		    if (lock == -1) {
-			    delay(0xFFFFF);
-		    }
-	    } while (lock == -1);
-    }
+	
+	if (lock == -1) {
+		do {
+			lock = open("/dev/urandom", O_RDONLY);
+			if (lock == -1) {
+				delay(0xFFFFF);
+			}
+		} while (lock == -1);
+	}
 
 	while (n > 0) {
 		do {


### PR DESCRIPTION
In some circumstances BCryptGenRandom can fail (for example, when
running within a Google Chrome sandboxed process). If this ever happens,
use RtlGenRandom instead to generate a cryptographically secure random
number.